### PR TITLE
Fixed styling error in PastOrder.js

### DIFF
--- a/src/components/PastOrder.js
+++ b/src/components/PastOrder.js
@@ -37,7 +37,7 @@ const PastOrder = (props) => {
       <h1>Past Orders</h1>
       <p>{productNewList}</p>
       <p>{props.date}</p>
-      <p>Total: ${totalCost} style={costStyle}</p>
+      <p style={costStyle}>Total: ${totalCost}</p>
     </div>
   )
 }


### PR DESCRIPTION
Moved styling rules into p tag (was previously set to display the actual rules on the page in jsx)

@Dajana8127 @Kerah-Jones @Alexis1618 